### PR TITLE
Add `static` to the `get_operator_rename` header

### DIFF
--- a/bbl/src/bbl-genbind.cpp
+++ b/bbl/src/bbl-genbind.cpp
@@ -35,7 +35,7 @@ enum Result {
     ERROR_FILE_OPEN,
 };
 
-auto get_operator_rename(std::string const& name) -> std::string;
+static auto get_operator_rename(std::string const& name) -> std::string;
 
 auto get_function_cast_string(FunctionDecl const* fd,
                               std::string const& scope,


### PR DESCRIPTION
The mismatch between the function stub and implementation gave me a compilation error when building on Linux/GCC.