### PR TITLE
Allow setting a custom dir to pull the clang includes from

### DIFF
--- a/bbl/CMakeLists.txt
+++ b/bbl/CMakeLists.txt
@@ -147,20 +147,24 @@ install(
     ${CMAKE_INSTALL_LIBDIR}/cmake/babble
 )
 
+if(NOT DEFINED LIBCLANG_DIR)
+  set(LIBCLANG_DIR ${CLANG_INSTALL_PREFIX})
+endif()
+
 # copy the clang resource dir to the installation so we can pick up the headers
 # first need to extract the major version to get the right path from the 
 # llvm installation
 install(
   DIRECTORY
-    ${CLANG_INSTALL_PREFIX}/lib/clang/${LLVM_VERSION_MAJOR}/include
+    ${LIBCLANG_DIR}/lib/clang/${LLVM_VERSION_MAJOR}/include
     DESTINATION
       ${CMAKE_INSTALL_LIBDIR}/resource
 )
 
 # also copy it to the binary dir so we can pick it up in the test runner
 file(
-  COPY 
-    ${CLANG_INSTALL_PREFIX}/lib/clang/${LLVM_VERSION_MAJOR}/include
+  COPY
+    ${LIBCLANG_DIR}/lib/clang/${LLVM_VERSION_MAJOR}/include
   DESTINATION
     ${CMAKE_BINARY_DIR}
 )


### PR DESCRIPTION
`${CLANG_INSTALL_PREFIX}/lib/clang/${LLVM_VERSION_MAJOR}/include` is invalid on systems that store the libs for clang seperately from wherever `CLANG_INSTALL_PREFIX` is.

E.g. on Nix/NixOS it points to `/nix/store/0y99g3631mcl08ym46a5803g0hr4rc8j-clang-16.0.6` which looks like:
```
/nix/store/0y99g3631mcl08ym46a5803g0hr4rc8j-clang-16.0.6/
├── bin
...
│   ├── clang -> clang-16
│   ├── clang-16
...
└── share
    ├── clang
...
```
but also `/nix/store/l92dv1igdpgkb1mxjv9rabvk795k45ih-clang-16.0.6-lib` which looks like:

```
/nix/store/l92dv1igdpgkb1mxjv9rabvk795k45ih-clang-16.0.6-lib
├── lib
│   ├── clang
│   │   └── 16
│   │       └── include
│   │           ├── __clang_cuda_builtin_vars.h
...
│   ├── libclang-cpp.so -> libclang-cpp.so.16
│   ├── libclang-cpp.so.16
...
```

Using a define for this directory lets me overwrite the value like so:
https://github.com/expenses/babble-nix/blob/b5ecce0864ccdad936adadd6514faf26fe8e93f8/package.nix#L14-L16

I'm happy to bikeshed on the naming of this variable.